### PR TITLE
[CHORE] Replace with lib with explicit inherit imports

### DIFF
--- a/modules/home/gui.nix
+++ b/modules/home/gui.nix
@@ -6,7 +6,9 @@
   ...
 }:
 
-with lib;
+let
+  inherit (lib) mkOption mkIf types;
+in
 {
   imports = [
     inputs.zen-browser.homeModules.twilight
@@ -77,19 +79,19 @@ with lib;
         cursor-style = "block";
         cursor-style-blink = true;
         shell-integration-features = "no-cursor";
-        
+
         # Enable clickable links
         link-url = true;
-        
+
         # Enable image protocols (Kitty image protocol)
         image-storage-limit = 320000000;
-        
+
         # Copy on select
         copy-on-select = true;
-        
+
         # Mouse behavior
         mouse-hide-while-typing = true;
-        
+
         # Clipboard settings
         clipboard-read = "ask";
         clipboard-write = "allow";

--- a/modules/services/desktop/default.nix
+++ b/modules/services/desktop/default.nix
@@ -6,7 +6,9 @@
   ...
 }:
 
-with lib;
+let
+  inherit (lib) mkOption mkIf types;
+in
 {
   options.modules.services.desktop = {
     autoLogin = mkOption {

--- a/modules/services/desktop/gnome.nix
+++ b/modules/services/desktop/gnome.nix
@@ -6,7 +6,17 @@
   ...
 }:
 
-with lib;
+let
+  inherit (lib)
+    mkOption
+    mkIf
+    types
+    literalExpression
+    foldl'
+    replaceStrings
+    attrNames
+    ;
+in
 {
   options.modules.services.desktop.gnome = {
     enable = mkOption {
@@ -93,7 +103,7 @@ with lib;
                 if config.modules.services.desktop.gnome.altDrag then "<Alt>" else "disabled";
               resize-with-right-button = config.modules.services.desktop.gnome.altDrag;
             };
-            
+
             # Custom keybindings for screenshots and screen recording
             "org/gnome/settings-daemon/plugins/media-keys" = {
               custom-keybindings = [
@@ -101,13 +111,13 @@ with lib;
                 "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/kooha/"
               ];
             };
-            
+
             "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot" = {
               name = "Flameshot Screenshot";
               command = "flameshot gui";
               binding = "<Control><Alt>s";
             };
-            
+
             "org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/kooha" = {
               name = "Kooha Screen Recording";
               command = "kooha";
@@ -119,13 +129,13 @@ with lib;
               # Convert extraGSettings from flat schema.key format to nested format
               convertSettings =
                 attrs:
-                lib.foldl' (
+                foldl' (
                   acc: schema:
                   acc
                   // {
-                    ${lib.replaceStrings [ "." ] [ "/" ] schema} = attrs.${schema};
+                    ${replaceStrings [ "." ] [ "/" ] schema} = attrs.${schema};
                   }
-                ) { } (lib.attrNames attrs);
+                ) { } (attrNames attrs);
             in
             if config.modules.services.desktop.gnome.extraGSettings != { } then
               convertSettings config.modules.services.desktop.gnome.extraGSettings

--- a/modules/services/desktop/graphics.nix
+++ b/modules/services/desktop/graphics.nix
@@ -5,7 +5,10 @@
   ...
 }:
 
-with lib;
+let
+  inherit (lib) mkOption mkIf types;
+  cfg = config.modules.services.desktop.graphics;
+in
 {
   options.modules.services.desktop.graphics = {
     enable = mkOption {
@@ -23,7 +26,7 @@ with lib;
     };
   };
 
-  config = mkIf config.modules.services.desktop.graphics.enable {
+  config = mkIf cfg.enable {
     hardware.graphics = {
       enable = true;
       enable32Bit = true;
@@ -32,7 +35,7 @@ with lib;
     hardware.nvidia = {
       modesetting.enable = true;
       open = false;
-      powerManagement.enable = config.modules.services.desktop.graphics.nvidia.powerManagement;
+      powerManagement.enable = cfg.nvidia.powerManagement;
       powerManagement.finegrained = false;
       nvidiaPersistenced = true;
       package = config.boot.kernelPackages.nvidiaPackages.stable;
@@ -61,15 +64,17 @@ with lib;
       '';
     };
 
-    environment.systemPackages = with pkgs; [
-      vulkan-loader
-      vulkan-tools
-      nvidia-vaapi-driver
-    ];
+    environment = {
+      systemPackages = with pkgs; [
+        vulkan-loader
+        vulkan-tools
+        nvidia-vaapi-driver
+      ];
 
-    environment.sessionVariables = {
-      LIBVA_DRIVER_NAME = "nvidia";
-      __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+      sessionVariables = {
+        LIBVA_DRIVER_NAME = "nvidia";
+        __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+      };
     };
   };
 }

--- a/modules/services/desktop/steam.nix
+++ b/modules/services/desktop/steam.nix
@@ -5,8 +5,13 @@
   ...
 }:
 
-with lib;
 let
+  inherit (lib)
+    mkOption
+    mkIf
+    types
+    optionals
+    ;
   isWayland = config.services.displayManager.gdm.wayland or false;
 in
 {
@@ -36,7 +41,7 @@ in
       gamescopeSession.enable = isWayland;
       remotePlay.openFirewall = config.modules.services.desktop.steam.remotePlay;
       dedicatedServer.openFirewall = false;
-      
+
       extraCompatPackages = with pkgs; [
         proton-ge-bin
       ];
@@ -55,8 +60,7 @@ in
       };
     };
 
-    environment.systemPackages = with pkgs;
-      optionals isWayland [ gamescope ];
+    environment.systemPackages = with pkgs; optionals isWayland [ gamescope ];
 
     hardware.steam-hardware.enable = true;
   };

--- a/modules/services/docker.nix
+++ b/modules/services/docker.nix
@@ -6,7 +6,15 @@
   ...
 }:
 
-with lib;
+let
+  inherit (lib)
+    mkOption
+    mkIf
+    mkMerge
+    types
+    listToAttrs
+    ;
+in
 {
   options.modules.docker = {
     enable = mkOption {


### PR DESCRIPTION
Replaces `with lib;` anti-pattern with explicit `inherit (lib) ...` imports

Per (best practices)[https://nix.dev/guides/best-practices#with-attrset-expression], doing the `with lib` pattern can cause issues w/ static analysis, and scoping rules can be unintuitive.

For our use case, this should be a pure refactor, no behavior changes