### PR TITLE
[FIX] Add nix-ld and desktop entries for OnlyOffice and Steam

### DIFF
--- a/modules/home/gui.nix
+++ b/modules/home/gui.nix
@@ -246,6 +246,33 @@ in
       };
     };
 
+    # NOTE: Custom desktop entry for OnlyOffice (the FHS-wrapped package points to /usr/bin which doesn't exist on NixOS)
+    xdg.desktopEntries.onlyoffice-desktopeditors = {
+      name = "ONLYOFFICE";
+      comment = "Edit office documents";
+      exec = "onlyoffice-desktopeditors %U";
+      icon = "onlyoffice-desktopeditors";
+      terminal = false;
+      type = "Application";
+      categories = [
+        "Office"
+        "WordProcessor"
+        "Spreadsheet"
+        "Presentation"
+      ];
+      mimeType = [
+        "application/vnd.oasis.opendocument.text"
+        "application/vnd.oasis.opendocument.spreadsheet"
+        "application/vnd.oasis.opendocument.presentation"
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        "application/msword"
+        "application/vnd.ms-excel"
+        "application/vnd.ms-powerpoint"
+      ];
+    };
+
     xdg.mimeApps =
       let
         zen-browser = inputs.zen-browser.packages.${pkgs.stdenv.hostPlatform.system}.twilight;

--- a/modules/services/desktop/graphics.nix
+++ b/modules/services/desktop/graphics.nix
@@ -27,6 +27,22 @@ in
   };
 
   config = mkIf cfg.enable {
+    # NOTE: Enable nix-ld for FHS-wrapped apps (like OnlyOffice) to find system libraries
+    programs.nix-ld = {
+      enable = true;
+      libraries = with pkgs; [
+        libGL
+        libGLU
+        xorg.libX11
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXi
+        xorg.libXext
+        xorg.libXrender
+        xorg.libXfixes
+      ];
+    };
+
     hardware.graphics = {
       enable = true;
       enable32Bit = true;

--- a/modules/services/desktop/steam.nix
+++ b/modules/services/desktop/steam.nix
@@ -12,6 +12,7 @@ let
     types
     optionals
     ;
+  cfg = config.modules.services.desktop.steam;
   isWayland = config.services.displayManager.gdm.wayland or false;
 in
 {
@@ -35,11 +36,11 @@ in
     };
   };
 
-  config = mkIf config.modules.services.desktop.steam.enable {
+  config = mkIf cfg.enable {
     programs.steam = {
       enable = true;
       gamescopeSession.enable = isWayland;
-      remotePlay.openFirewall = config.modules.services.desktop.steam.remotePlay;
+      remotePlay.openFirewall = cfg.remotePlay;
       dedicatedServer.openFirewall = false;
 
       extraCompatPackages = with pkgs; [
@@ -47,7 +48,7 @@ in
       ];
     };
 
-    programs.gamemode = mkIf config.modules.services.desktop.steam.gamemode {
+    programs.gamemode = mkIf cfg.gamemode {
       enable = true;
       settings = {
         general = {
@@ -63,5 +64,24 @@ in
     environment.systemPackages = with pkgs; optionals isWayland [ gamescope ];
 
     hardware.steam-hardware.enable = true;
+
+    # NOTE: Custom desktop entry to fix Steam not launching from Walker on first try
+    home-manager.sharedModules = [
+      {
+        xdg.desktopEntries.steam = {
+          name = "Steam";
+          comment = "Application for managing and playing games on Steam";
+          exec = ''bash -c "steam steam://open/games || steam"'';
+          icon = "steam";
+          terminal = false;
+          type = "Application";
+          categories = [
+            "Network"
+            "FileTransfer"
+            "Game"
+          ];
+        };
+      }
+    ];
   };
 }


### PR DESCRIPTION
Fixes apps not launching correctly from Walker launcher:
- OnlyOffice FHS-wrapped package needs `nix-ld` for system libraries
- Steam needs custom desktop entry to work with `walker` on first launch