### PR TITLE
[FIX] Configure elephant to use systemd-run for application launching

### DIFF
--- a/modules/home/gui.nix
+++ b/modules/home/gui.nix
@@ -246,32 +246,7 @@ in
       };
     };
 
-    # NOTE: Custom desktop entry for OnlyOffice (the FHS-wrapped package points to /usr/bin which doesn't exist on NixOS)
-    xdg.desktopEntries.onlyoffice-desktopeditors = {
-      name = "ONLYOFFICE";
-      comment = "Edit office documents";
-      exec = "onlyoffice-desktopeditors %U";
-      icon = "onlyoffice-desktopeditors";
-      terminal = false;
-      type = "Application";
-      categories = [
-        "Office"
-        "WordProcessor"
-        "Spreadsheet"
-        "Presentation"
-      ];
-      mimeType = [
-        "application/vnd.oasis.opendocument.text"
-        "application/vnd.oasis.opendocument.spreadsheet"
-        "application/vnd.oasis.opendocument.presentation"
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        "application/msword"
-        "application/vnd.ms-excel"
-        "application/vnd.ms-powerpoint"
-      ];
-    };
+
 
     xdg.mimeApps =
       let

--- a/modules/home/gui.nix
+++ b/modules/home/gui.nix
@@ -246,8 +246,6 @@ in
       };
     };
 
-
-
     xdg.mimeApps =
       let
         zen-browser = inputs.zen-browser.packages.${pkgs.stdenv.hostPlatform.system}.twilight;

--- a/modules/services/desktop/niri.nix
+++ b/modules/services/desktop/niri.nix
@@ -222,7 +222,7 @@ in
             enable = true;
             provider = {
               desktopapplications.settings = {
-                launch_prefix = "";
+                launch_prefix = "systemd-run --user --scope --";
               };
               symbols.settings = {
                 locale = "en";

--- a/modules/services/desktop/steam.nix
+++ b/modules/services/desktop/steam.nix
@@ -64,7 +64,5 @@ in
     environment.systemPackages = with pkgs; optionals isWayland [ gamescope ];
 
     hardware.steam-hardware.enable = true;
-
-
   };
 }

--- a/modules/services/desktop/steam.nix
+++ b/modules/services/desktop/steam.nix
@@ -65,23 +65,6 @@ in
 
     hardware.steam-hardware.enable = true;
 
-    # NOTE: Custom desktop entry to fix Steam not launching from Walker on first try
-    home-manager.sharedModules = [
-      {
-        xdg.desktopEntries.steam = {
-          name = "Steam";
-          comment = "Application for managing and playing games on Steam";
-          exec = ''bash -c "steam steam://open/games || steam"'';
-          icon = "steam";
-          terminal = false;
-          type = "Application";
-          categories = [
-            "Network"
-            "FileTransfer"
-            "Game"
-          ];
-        };
-      }
-    ];
+
   };
 }


### PR DESCRIPTION
Fixes a bug where `walker` would not launching OnlyOffice and Steam by using `systemd-run --user --scope --` as a launch prefix.

Removes hacky custom `.desktop` entries as a result.