### PR TITLE
docs(git): clarify breaking change syntax in skill documentation

### DIFF
--- a/modules/home/tui/claude-code/skills/git/SKILL.md
+++ b/modules/home/tui/claude-code/skills/git/SKILL.md
@@ -100,7 +100,7 @@ refactor(api): simplify authentication flow
 
 ## Breaking Changes
 
-Add `!` after type or `BREAKING CHANGE:` in footer:
+Add an exclamation mark (`!`) after type and use `BREAKING CHANGE:` in footer:
 
 ```
 feat(api)!: change authentication endpoint


### PR DESCRIPTION
Clarifies that breaking changes require BOTH `!` after type AND `BREAKING CHANGE:` footer for proper semantic versioning.