### PR TITLE
feat(suspend): add custom auto-suspend service with inhibitor bypass

### DIFF
--- a/hosts/linux/madoka/services.nix
+++ b/hosts/linux/madoka/services.nix
@@ -30,6 +30,10 @@
 
       suspend = {
         enable = true;
+        idleMinutesAC = 15;
+        idleMinutesBattery = 15;
+        checkIntervalMinutes = 1;
+
         usb.disable = [
           {
             vendor = "046d";


### PR DESCRIPTION
Replaces GNOME's auto-suspend with a stupid simple systemd-based service.