### PR TITLE
fix(nvim): update treesitter config for new API

### DIFF
--- a/modules/home/tui.nix
+++ b/modules/home/tui.nix
@@ -71,6 +71,7 @@ with lib;
           git-crypt
           lf
           socat
+          tree-sitter
           # Dependencies for lf previewer
           poppler-utils # provides pdftotext
           highlight

--- a/modules/home/tui/neovim/lua/plugins/treesitter.lua
+++ b/modules/home/tui/neovim/lua/plugins/treesitter.lua
@@ -1,32 +1,20 @@
 return {
-  { -- Highlight, edit, and navigate code
+  {
     'nvim-treesitter/nvim-treesitter',
+    lazy = false,
     build = ':TSUpdate',
-    opts = {
-      ensure_installed = { 'bash', 'c', 'diff', 'erlang', 'elixir', 'html', 'lua', 'luadoc', 'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc' },
-      -- Autoinstall languages that are not installed
-      auto_install = true,
-      highlight = {
-        enable = true,
-        -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
-        --  If you are experiencing weird indenting issues, add the language to
-        --  the list of additional_vim_regex_highlighting and disabled languages for indent.
-        additional_vim_regex_highlighting = { 'ruby' },
-      },
-      indent = { enable = true, disable = { 'ruby' } },
-    },
-    config = function(_, opts)
-      -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
+    config = function()
+      require('nvim-treesitter').setup({})
+      require('nvim-treesitter').install({
+        'bash', 'c', 'diff', 'erlang', 'elixir', 'html', 'lua', 'luadoc',
+        'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc',
+      })
 
-      ---@diagnostic disable-next-line: missing-fields
-      require('nvim-treesitter.configs').setup(opts)
-
-      -- There are additional nvim-treesitter modules that you can use to interact
-      -- with nvim-treesitter. You should go explore a few and see what interests you:
-      --
-      --    - Incremental selection: Included, see `:help nvim-treesitter-incremental-selection-mod`
-      --    - Show your current context: https://github.com/nvim-treesitter/nvim-treesitter-context
-      --    - Treesitter + textobjects: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
+      vim.api.nvim_create_autocmd('FileType', {
+        callback = function()
+          pcall(vim.treesitter.start)
+        end,
+      })
     end,
   },
 }


### PR DESCRIPTION
- Updates nvim-treesitter config to use the new API after their full rewrite
- Adds `tree-sitter` CLI to packages (required for parser compilation)