### PR TITLE
feat(camera): add stable IPU7 webcam stack for XPS 13 9350

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It uses **flake-parts** to help with organization and modularity:
 │   └── home.nix
 ├── modules/                     # Reusable modules
 │   ├── hardware/                ## Hardware-specific modules
+│   │   └── dell/xps/13-9350/    ## XPS 13 9350 hardware fixes
 │   ├── home/                    ## User-specific modules, applications
 │   │   ├── gui/
 │   │   ├── tui/
@@ -32,6 +33,8 @@ It uses **flake-parts** to help with organization and modularity:
 │   │   └── tui.nix              ## TUI applications
 │   └── services/                ## Background service modules
 ├── overlays/                    # Overlays
+├── packages/                    # Local package derivations
+│   └── linux/                   ## Out-of-tree kernel module packages
 ├── secrets/                     # Encrypted secrets
 └── bin/                         # Custom scripts, utilities
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1767637959,
-        "narHash": "sha256-+gBU5Cj9QNpHLQ5PHJoWNQft7TMsBM6X+tDQg+/B2P0=",
+        "lastModified": 1775866625,
+        "narHash": "sha256-NfzRZ5DZo8Mwb31ocimy3IMhr3kmYGQ3/ImfnEQkQLw=",
         "owner": "9001",
         "repo": "copyparty",
-        "rev": "038af507772593b904b5c3efc306f89cbdf2b6fb",
+        "rev": "a5d859d2b18f53ccf236bc6229856f79139d531c",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1765739568,
-        "narHash": "sha256-gQYx35Of4UDKUjAYvmxjUEh/DdszYeTtT6MDin4loGE=",
+        "lastModified": 1775790182,
+        "narHash": "sha256-pG2RWVQY0Pe+rmmXJx+Jpyi+JcgjWzS18m7fcD1B64Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "67d2baff0f9f677af35db61b32b5df6863bcc075",
+        "rev": "534982f1c41834b101e381b07b1121a4f065a374",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1773155327,
-        "narHash": "sha256-FAHsMDOCinoHaeCnFHU/KLaIXkW1UiSd5JHm2pwuddI=",
+        "lastModified": 1776066897,
+        "narHash": "sha256-szNN3hDh/Xfb2Be8zPjKSMKFw435OYiTQfMRZrBf1SQ=",
         "owner": "tomasz-tomczyk",
         "repo": "crit",
-        "rev": "c25ef7aa1b4df385bcbde82fa48c86a8e809d4a9",
+        "rev": "dcbdf7f2127810ef21b572cc174314ed772bb6af",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1765121682,
-        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -134,24 +134,6 @@
       }
     },
     "flake-utils_2": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "inputs": {
         "systems": "systems_2"
       },
@@ -178,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768935149,
-        "narHash": "sha256-S5/BZo4X1D9+U/yJ6xCJyUkXZ8y261q2gPP5Xsq8RPU=",
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "18cbede9ff6da05b911c5c4802a397c2686ac8fa",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -219,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767738364,
-        "narHash": "sha256-rmAerMcKMYusVs5B88RAKAYUiENrO+d4bjvpQkkaaks=",
+        "lastModified": 1776046499,
+        "narHash": "sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e8b7bef66c60735982369f3151b93e62fe37da7",
+        "rev": "287f84846c1eb3b72c986f5f6bebcff0bd67440d",
         "type": "github"
       },
       "original": {
@@ -240,11 +222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767104570,
-        "narHash": "sha256-GKgwu5//R+cLdKysZjGqvUEEOGXXLdt93sNXeb2M/Lk=",
+        "lastModified": 1774991950,
+        "narHash": "sha256-kScKj3qJDIWuN9/6PMmgy5esrTUkYinrO5VvILik/zw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4e78a2cbeaddd07ab7238971b16468cc1d14daf",
+        "rev": "f2d3e04e278422c7379e067e323734f3e8c585a7",
         "type": "github"
       },
       "original": {
@@ -256,15 +238,15 @@
     "nix-minecraft": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1767147099,
-        "narHash": "sha256-395ehjdAtaqCbKmx+PhKAqnkYLvTtAzq2qzFG9qaGDw=",
+        "lastModified": 1776051551,
+        "narHash": "sha256-zqDhVyUtctq7HlpMC9cdR277ner0L/f7SkC3oKbZwy0=",
         "owner": "Infinidoge",
         "repo": "nix-minecraft",
-        "rev": "01f571579edd64433f97c4294137fbc366deef4b",
+        "rev": "c5eb01b60873e331265779028a839cd2b5237874",
         "type": "github"
       },
       "original": {
@@ -281,11 +263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765841014,
-        "narHash": "sha256-55V0AJ36V5Egh4kMhWtDh117eE3GOjwq5LhwxDn9eHg=",
+        "lastModified": 1774972752,
+        "narHash": "sha256-DnLIpFxznohpLkIFs390uZ0gxwkVyhtknhKNu+lQJK8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "be4af8042e7a61fa12fda58fe9a3b3babdefe17b",
+        "rev": "d97e078f4788cddb8d11c3c99f72a4bb9ddec221",
         "type": "github"
       },
       "original": {
@@ -311,11 +293,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -326,11 +308,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1767051569,
-        "narHash": "sha256-0MnuWoN+n1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "40ee5e1944bebdd128f9fbada44faefddfde29bd",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -358,11 +340,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
@@ -374,11 +356,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767640445,
-        "narHash": "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f0c42f8bc7151b8e7e5840fb3bd454ad850d8c5",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {
@@ -406,11 +388,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
         "type": "github"
       },
       "original": {
@@ -422,15 +404,15 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
-        "owner": "nixos",
+        "lastModified": 1775763530,
+        "narHash": "sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -480,11 +462,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765939271,
-        "narHash": "sha256-7F/d+ZrTYyOxnBZcleQZjOOEWc1IMXR/CLLRLLsVtHo=",
+        "lastModified": 1775790837,
+        "narHash": "sha256-RAHjn8sjgfF3D17BaV8iv69o3P+L9aCuE36PFwzoqHU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8028944c1339469124639da276d403d8ab7929a8",
+        "rev": "c913e0b9525311f103b7e1463ebb0f28c6865d8d",
         "type": "github"
       },
       "original": {
@@ -528,11 +510,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1767738644,
-        "narHash": "sha256-aZA7+Ii7TCXjP7pLYnkLZUP4eVnGWkqhcRz35spkznc=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bf72e5e007f8e75a485f5c24ffaeee663f6c222e",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {
@@ -549,11 +531,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767568852,
-        "narHash": "sha256-6s8hL3YX9zAq2T7qvcwwzaEVwc9MEYbW+C2LcAAQfbk=",
+        "lastModified": 1775961625,
+        "narHash": "sha256-8SjilptVv9dSTvn0Z5j65vHHu+flmPXeyrGaSyRJm7U=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "350c729b261e6f5529460140a5f0943dd4c5e156",
+        "rev": "0eaab249f5ca1c55921e99cfe07187410758c9fa",
         "type": "github"
       },
       "original": {
@@ -565,16 +547,16 @@
     "zjstatus": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_7",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1766016463,
-        "narHash": "sha256-aWp608krMtk5I+c3GXyuHkb6ugah40cBI0R52fNqMiI=",
+        "lastModified": 1775885119,
+        "narHash": "sha256-YNcOUBFt3dYFbhpgIGEPTdBi5vH3LbEGfRoTUokfmyw=",
         "owner": "dj95",
         "repo": "zjstatus",
-        "rev": "9a4b88fdceee8eb2b8c28111c53e94254d61c994",
+        "rev": "4ef69ff55930373d60f6c85afc39b2494850feeb",
         "type": "github"
       },
       "original": {

--- a/hosts/linux/configuration.nix
+++ b/hosts/linux/configuration.nix
@@ -18,6 +18,8 @@
       "wheel"
       "docker"
       "media"
+      "audio"
+      "video"
     ];
     shell = pkgs.fish;
   };

--- a/hosts/linux/iroha/default.nix
+++ b/hosts/linux/iroha/default.nix
@@ -1,23 +1,13 @@
-{
-  pkgs,
-  ...
-}:
+{ ... }:
 
 {
   imports = [
     ./hardware-configuration.nix
     ./services.nix
+    ../../../modules/hardware/dell/xps/13-9350
   ];
 
   boot = {
-    kernelPackages = pkgs.linuxPackages_latest;
-
-    # Fix for Lunar Lake Arc Graphics screen glitches
-    # Disables Panel Self Refresh (PSR) which causes horizontal lines/flickering
-    kernelParams = [
-      "xe.enable_psr=0"
-    ];
-
     loader = {
       systemd-boot.enable = true;
       efi = {

--- a/hosts/linux/iroha/services.nix
+++ b/hosts/linux/iroha/services.nix
@@ -28,4 +28,5 @@
       steam.enable = true;
     };
   };
+
 }

--- a/modules/hardware/dell/xps/13-9350/0001-ov02c10-force-default-rotation-180-v7.patch
+++ b/modules/hardware/dell/xps/13-9350/0001-ov02c10-force-default-rotation-180-v7.patch
@@ -1,0 +1,24 @@
+--- a/drivers/media/i2c/ov02c10.c
++++ b/drivers/media/i2c/ov02c10.c
+@@ -461,17 +461,15 @@
+ 		break;
+ 
+ 	case V4L2_CID_HFLIP:
+-		cci_write(ov02c10->regmap, OV02C10_ISP_X_WIN_CONTROL,
+-			  ctrl->val ? 2 : 1, &ret);
++		cci_write(ov02c10->regmap, OV02C10_ISP_X_WIN_CONTROL, 2, &ret);
+ 		cci_update_bits(ov02c10->regmap, OV02C10_ROTATE_CONTROL,
+-				BIT(3), ctrl->val ? 0 : BIT(3), &ret);
++				BIT(3), 0, &ret);
+ 		break;
+ 
+ 	case V4L2_CID_VFLIP:
+-		cci_write(ov02c10->regmap, OV02C10_ISP_Y_WIN_CONTROL,
+-			  ctrl->val ? 2 : 1, &ret);
++		cci_write(ov02c10->regmap, OV02C10_ISP_Y_WIN_CONTROL, 2, &ret);
+ 		cci_update_bits(ov02c10->regmap, OV02C10_ROTATE_CONTROL,
+-				BIT(4), ctrl->val << 4, &ret);
++				BIT(4), BIT(4), &ret);
+ 		break;
+ 
+ 	default:

--- a/modules/hardware/dell/xps/13-9350/0001-ov02c10-force-default-rotation-180.patch
+++ b/modules/hardware/dell/xps/13-9350/0001-ov02c10-force-default-rotation-180.patch
@@ -1,0 +1,24 @@
+--- a/drivers/media/i2c/ov02c10.c
++++ b/drivers/media/i2c/ov02c10.c
+@@ -461,17 +461,15 @@
+ 		break;
+ 
+ 	case V4L2_CID_HFLIP:
+-		cci_write(ov02c10->regmap, OV02C10_ISP_X_WIN_CONTROL,
+-			  ctrl->val ? 2 : 1, &ret);
++		cci_write(ov02c10->regmap, OV02C10_ISP_X_WIN_CONTROL, 2, &ret);
+ 		cci_update_bits(ov02c10->regmap, OV02C10_ROTATE_CONTROL,
+-				BIT(3), ctrl->val ? 0 : BIT(3), &ret);
++				BIT(3), 0, &ret);
+ 		break;
+ 
+ 	case V4L2_CID_VFLIP:
+-		cci_write(ov02c10->regmap, OV02C10_ISP_Y_WIN_CONTROL,
+-			  ctrl->val ? 2 : 1, &ret);
++		cci_write(ov02c10->regmap, OV02C10_ISP_Y_WIN_CONTROL, 2, &ret);
+ 		cci_update_bits(ov02c10->regmap, OV02C10_ROTATE_CONTROL,
+-				BIT(4), ov02c10->vflip->val << 4, &ret);
++				BIT(4), BIT(4), &ret);
+ 		break;
+ 
+ 	default:

--- a/modules/hardware/dell/xps/13-9350/camera-ipu7.nix
+++ b/modules/hardware/dell/xps/13-9350/camera-ipu7.nix
@@ -1,0 +1,126 @@
+{
+  pkgs,
+  config,
+  ...
+}:
+
+{
+  boot = {
+    kernelPackages = pkgs.linuxPackages_testing;
+
+    kernelPatches = [
+      {
+        # Fixes wrong webcam colors after upstream OV02C10 flip changes.
+        name = "ov02c10-fix-bayer-pattern-after-default-vflip";
+        patch = pkgs.fetchurl {
+          url = "https://github.com/torvalds/linux/commit/905120d7470e5ed79d59b61ef6aa13344ffca229.patch";
+          hash = "sha256-Tir4Z6yP/t1mlpj6+fWLoWFa9tZ/8aEVEDWj7Wk4ajc=";
+        };
+      }
+      {
+        # Keeps colors stable when apps toggle camera flip controls.
+        name = "ov02c10-preserve-bayer-pattern-on-flip-changes";
+        patch = pkgs.fetchurl {
+          url = "https://github.com/torvalds/linux/commit/d0bb6f1f2b79d96953bf81a3839ac2aa946ba2fa.patch";
+          hash = "sha256-Fad0aRdKTkCALz5oFB1mJ7KJQ8XIXyvIK/ArAWUYhrw=";
+        };
+      }
+      {
+        # Fixes mirrored image behavior from the sensor hflip control.
+        name = "ov02c10-fix-horizontal-flip-control";
+        patch = pkgs.fetchurl {
+          url = "https://github.com/torvalds/linux/commit/1d2e3b4443a85374fdd6fb8fd2c015e3e3e16100.patch";
+          hash = "sha256-4qEYNDWYoxI2/UGTAGv+uEa38jx9eCNjEkYZk+zlEDA=";
+        };
+      }
+      {
+        # Prevents userspace from flipping this webcam upside down.
+        name = "ov02c10-force-default-rotation-180";
+        patch = ./0001-ov02c10-force-default-rotation-180.patch;
+      }
+    ];
+
+    extraModulePackages = [
+      (config.boot.kernelPackages.callPackage ../../../../../packages/linux/ipu7-drivers/default.nix { })
+      (config.boot.kernelPackages.callPackage ../../../../../packages/linux/vision-drivers/default.nix
+        { }
+      )
+    ];
+
+    extraModprobeConfig = ''
+      options v4l2loopback devices=0
+      softdep intel_cvs pre: usbio gpio_usbio i2c_usbio
+      softdep ov02c10 pre: intel_cvs
+    '';
+
+    kernelModules = [
+      "usbio"
+      "gpio_usbio"
+      "i2c_usbio"
+      "intel_cvs"
+      "intel_skl_int3472_common"
+      "intel_skl_int3472_discrete"
+      "ov02c10"
+    ];
+  };
+
+  hardware.firmware = with pkgs; [
+    ipu7-camera-bins
+    ivsc-firmware
+  ];
+
+  services = {
+    udev.extraRules = ''
+      SUBSYSTEM=="intel-ipu7-psys", MODE="0660", GROUP="video"
+    '';
+
+    # PipeWire apps should use the stable libcamera source, not raw IPU nodes.
+    pipewire.wireplumber.extraConfig."90-ipu7-camera" = {
+      "wireplumber.profiles" = {
+        main = {
+          "monitor.libcamera" = "required";
+        };
+      };
+
+      "monitor.v4l2.rules" = [
+        {
+          matches = [
+            {
+              "api.v4l2.path" = "~^/dev/video([0-9]|[12][0-9]|3[01])$";
+            }
+          ];
+          actions = {
+            update-props = {
+              "device.disabled" = true;
+              "node.disabled" = true;
+            };
+          };
+        }
+        {
+          matches = [
+            {
+              "api.v4l2.path" = "/dev/video32";
+            }
+          ];
+          actions = {
+            update-props = {
+              "node.disabled" = true;
+            };
+          };
+        }
+      ];
+    };
+
+    # Creates a compatibility /dev/video node for apps like Slack and Teams.
+    v4l2-relayd.instances.ipu7 = {
+      enable = true;
+      cardLabel = "Intel MIPI Camera";
+      extraPackages = [ pkgs.icamerasrc-ipu7x ];
+      input = {
+        pipeline = "icamerasrc";
+        format = "NV12";
+      };
+    };
+  };
+
+}

--- a/modules/hardware/dell/xps/13-9350/camera-ipu7.nix
+++ b/modules/hardware/dell/xps/13-9350/camera-ipu7.nix
@@ -1,42 +1,55 @@
 {
+  lib,
   pkgs,
   config,
   ...
 }:
 
+let
+  isPre70Kernel = lib.versionOlder config.boot.kernelPackages.kernel.version "7.0";
+
+  ov02c10Backports = lib.optionals isPre70Kernel [
+    {
+      # Fixes wrong webcam colors after upstream OV02C10 flip changes.
+      name = "ov02c10-fix-bayer-pattern-after-default-vflip";
+      patch = pkgs.fetchurl {
+        url = "https://github.com/torvalds/linux/commit/905120d7470e5ed79d59b61ef6aa13344ffca229.patch";
+        hash = "sha256-Tir4Z6yP/t1mlpj6+fWLoWFa9tZ/8aEVEDWj7Wk4ajc=";
+      };
+    }
+    {
+      # Keeps colors stable when apps toggle camera flip controls.
+      name = "ov02c10-preserve-bayer-pattern-on-flip-changes";
+      patch = pkgs.fetchurl {
+        url = "https://github.com/torvalds/linux/commit/d0bb6f1f2b79d96953bf81a3839ac2aa946ba2fa.patch";
+        hash = "sha256-Fad0aRdKTkCALz5oFB1mJ7KJQ8XIXyvIK/ArAWUYhrw=";
+      };
+    }
+    {
+      # Fixes mirrored image behavior from the sensor hflip control.
+      name = "ov02c10-fix-horizontal-flip-control";
+      patch = pkgs.fetchurl {
+        url = "https://github.com/torvalds/linux/commit/1d2e3b4443a85374fdd6fb8fd2c015e3e3e16100.patch";
+        hash = "sha256-4qEYNDWYoxI2/UGTAGv+uEa38jx9eCNjEkYZk+zlEDA=";
+      };
+    }
+  ];
+
+  ov02c10ForcePatch =
+    if isPre70Kernel then
+      ./0001-ov02c10-force-default-rotation-180.patch
+    else
+      ./0001-ov02c10-force-default-rotation-180-v7.patch;
+in
 {
   boot = {
     kernelPackages = pkgs.linuxPackages_testing;
 
-    kernelPatches = [
-      {
-        # Fixes wrong webcam colors after upstream OV02C10 flip changes.
-        name = "ov02c10-fix-bayer-pattern-after-default-vflip";
-        patch = pkgs.fetchurl {
-          url = "https://github.com/torvalds/linux/commit/905120d7470e5ed79d59b61ef6aa13344ffca229.patch";
-          hash = "sha256-Tir4Z6yP/t1mlpj6+fWLoWFa9tZ/8aEVEDWj7Wk4ajc=";
-        };
-      }
-      {
-        # Keeps colors stable when apps toggle camera flip controls.
-        name = "ov02c10-preserve-bayer-pattern-on-flip-changes";
-        patch = pkgs.fetchurl {
-          url = "https://github.com/torvalds/linux/commit/d0bb6f1f2b79d96953bf81a3839ac2aa946ba2fa.patch";
-          hash = "sha256-Fad0aRdKTkCALz5oFB1mJ7KJQ8XIXyvIK/ArAWUYhrw=";
-        };
-      }
-      {
-        # Fixes mirrored image behavior from the sensor hflip control.
-        name = "ov02c10-fix-horizontal-flip-control";
-        patch = pkgs.fetchurl {
-          url = "https://github.com/torvalds/linux/commit/1d2e3b4443a85374fdd6fb8fd2c015e3e3e16100.patch";
-          hash = "sha256-4qEYNDWYoxI2/UGTAGv+uEa38jx9eCNjEkYZk+zlEDA=";
-        };
-      }
+    kernelPatches = ov02c10Backports ++ [
       {
         # Prevents userspace from flipping this webcam upside down.
         name = "ov02c10-force-default-rotation-180";
-        patch = ./0001-ov02c10-force-default-rotation-180.patch;
+        patch = ov02c10ForcePatch;
       }
     ];
 

--- a/modules/hardware/dell/xps/13-9350/default.nix
+++ b/modules/hardware/dell/xps/13-9350/default.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+  imports = [
+    ./camera-ipu7.nix
+    ./microphone.nix
+  ];
+
+  boot.kernelParams = [
+    "xe.enable_psr=0" # Disable PSR, which causes screen flicker/glitches.
+    "snd_intel_dspcfg.dsp_driver=3" # Force SOF audio path so internal mic works.
+  ];
+}

--- a/modules/hardware/dell/xps/13-9350/microphone.nix
+++ b/modules/hardware/dell/xps/13-9350/microphone.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+
+{
+  systemd.services.xps13-9350-rt714-mic-workaround = {
+    description = "Apply RT714 SoundWire microphone mixer workaround";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "sound.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      for _ in $(seq 1 30); do
+        if ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 ADC 22 Mux" "DMIC2" >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 ADC 23 Mux" "DMIC2" >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 ADC 24 Mux" "DMIC2" >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 ADC 25 Mux" "DMIC2" >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 FU06" cap 63 on >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 FU0A" cap 63 on >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 FU0C Boost" 2 >/dev/null 2>&1 \
+          && ${pkgs.alsa-utils}/bin/amixer -c 0 sset "rt714 FU0E Boost" 2 >/dev/null 2>&1; then
+          exit 0
+        fi
+        sleep 1
+      done
+
+      exit 0
+    '';
+  };
+}

--- a/modules/services/desktop/gnome.nix
+++ b/modules/services/desktop/gnome.nix
@@ -291,6 +291,7 @@ in
         [
           adwaita-icon-theme
           nautilus
+          snapshot
           gnome-calculator
           gnome-system-monitor
           bibata-cursors

--- a/overlays/ipu7-camera-hal-uint32.patch
+++ b/overlays/ipu7-camera-hal-uint32.patch
@@ -1,0 +1,21 @@
+From f8ea16f7c4cc29201f39659b664ac40f6d1b0a49 Mon Sep 17 00:00:00 2001
+From: Hao Yao <hao.yao@intel.com>
+Date: Mon, 29 Sep 2025 16:55:12 +0800
+Subject: [PATCH] Fix missing definition of uint32_t
+
+Signed-off-by: Hao Yao <hao.yao@intel.com>
+---
+ src/platformdata/gc/HalStream.h                                 | 2 ++
+ 1 files changed, 2 insertions(+), 0 deletions(-)
+
+diff --git a/src/platformdata/gc/HalStream.h b/src/platformdata/gc/HalStream.h
+index 1ef32a3..799a140 100644
+--- a/src/platformdata/gc/HalStream.h
++++ b/src/platformdata/gc/HalStream.h
+@@ -16,6 +16,8 @@
+ 
+ #pragma once
+ 
++#include <stdint.h>
++
+ namespace icamera {

--- a/overlays/ipu7-camera.nix
+++ b/overlays/ipu7-camera.nix
@@ -1,0 +1,242 @@
+_: final: prev:
+let
+  # XPS 13 9350 webcam support depends on Intel IPU7 userspace pieces that are
+  # not fully available in our base nixpkgs snapshot yet.
+  # This overlay provides those packages globally so hardware modules can consume them.
+
+  # Camera HAL userspace plugin used by the Intel camera stack.
+  ipu7CameraHalPkg =
+    {
+      lib,
+      stdenv,
+      fetchFromGitHub,
+      cmake,
+      pkg-config,
+      expat,
+      ipu7-camera-bins,
+      jsoncpp,
+      libtool,
+      gst_all_1,
+      libdrm,
+      ipuVersion ? "ipu7x",
+    }:
+    let
+      ipuTarget =
+        {
+          ipu7x = "ipu_lnl";
+          ipu75xa = "ipu_lnl";
+        }
+        .${ipuVersion};
+    in
+    stdenv.mkDerivation {
+      pname = "${ipuVersion}-camera-hal";
+      version = "unstable-2025-01-15";
+
+      src = fetchFromGitHub {
+        owner = "intel";
+        repo = "ipu7-camera-hal";
+        rev = "431ff3f46ef821458d973390c8a88687637290c2";
+        hash = "sha256-/bSH+NJgVQ4HoW6yDlZGyg9EqTs+t0S3ZibVwl7IWf4=";
+      };
+
+      patches = [
+        ./ipu7-camera-hal-uint32.patch
+      ];
+
+      nativeBuildInputs = [
+        cmake
+        pkg-config
+      ];
+
+      cmakeFlags = [
+        "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+        "-DCMAKE_INSTALL_LIBDIR=lib"
+        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        "-DBUILD_CAMHAL_ADAPTOR=ON"
+        "-DBUILD_CAMHAL_PLUGIN=ON"
+        "-DIPU_VERSIONS=${ipuVersion}"
+        "-DUSE_STATIC_GRAPH=ON"
+        "-DUSE_STATIC_GRAPH_AUTOGEN=ON"
+      ];
+
+      NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
+      enableParallelBuilding = true;
+
+      buildInputs = [
+        expat
+        ipu7-camera-bins
+        jsoncpp
+        libtool
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        libdrm
+      ];
+
+      postPatch = ''
+        substituteInPlace src/platformdata/JsonParserBase.h \
+          --replace-fail '<jsoncpp/json/json.h>' '<json/json.h>'
+      '';
+
+      postInstall = ''
+        mkdir -p $out/include/${ipuTarget}/
+        cp -r $src/include $out/include/${ipuTarget}/libcamhal
+      '';
+
+      postFixup = ''
+        for lib in $out/lib/*.so; do
+          patchelf --add-rpath "${ipu7-camera-bins}/lib" $lib
+        done
+      '';
+
+      passthru = {
+        inherit ipuVersion ipuTarget;
+      };
+
+      meta = with lib; {
+        description = "HAL for processing of images in userspace";
+        homepage = "https://github.com/intel/ipu7-camera-hal";
+        license = licenses.asl20;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+
+  # GStreamer source plugin that exposes the Intel MIPI camera stream.
+  icamerasrcIpuPkg =
+    {
+      lib,
+      stdenv,
+      fetchFromGitHub,
+      autoreconfHook,
+      pkg-config,
+      gst_all_1,
+      ipuCameraHal,
+      libdrm,
+      libva,
+      apple-sdk_gstreamer ? null,
+    }:
+    stdenv.mkDerivation {
+      pname = "icamerasrc-${ipuCameraHal.ipuVersion}";
+      version = "unstable-2024-11-29";
+
+      src = fetchFromGitHub {
+        owner = "intel";
+        repo = "icamerasrc";
+        rev = "ee8526451ca1bb4957702de2f46138b63151f34c";
+        hash = "sha256-GX67+A77/YQBwqqbBiDHrkiKb2CMAO5CJTwm1XyQOkg=";
+      };
+
+      nativeBuildInputs = [
+        autoreconfHook
+        pkg-config
+      ];
+
+      preConfigure = ''
+        export CHROME_SLIM_CAMHAL=ON
+      '';
+
+      configureFlags = [
+        "--enable-gstdrmformat=yes"
+      ];
+
+      buildInputs = [
+        gst_all_1.gstreamer
+        gst_all_1.gst-plugins-base
+        gst_all_1.gst-plugins-bad
+        ipuCameraHal
+        libdrm
+        libva
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_gstreamer ];
+
+      NIX_CFLAGS_COMPILE = [
+        "-Wno-error"
+        "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0"
+      ];
+
+      enableParallelBuilding = true;
+
+      passthru = {
+        inherit (ipuCameraHal) ipuVersion;
+      };
+
+      meta = with lib; {
+        description = "GStreamer plugin for Intel MIPI cameras on IPU7";
+        homepage = "https://github.com/intel/icamerasrc/tree/icamerasrc_slim_api";
+        license = licenses.lgpl21Plus;
+        platforms = [ "x86_64-linux" ];
+      };
+    };
+in
+{
+  # Firmware + binary userspace libs required by Intel's IPU7 stack.
+  ipu7-camera-bins = prev.stdenv.mkDerivation {
+    pname = "ipu7-camera-bins";
+    version = "unstable-2025-01-15";
+
+    src = prev.fetchFromGitHub {
+      owner = "intel";
+      repo = "ipu7-camera-bins";
+      rev = "f4a353c7c2f0dc98416cd847a74724e8d6e07519";
+      hash = "sha256-4LOFOIdBSMITNA1RtH8TDwPd+r/0lyTA6RBPeD0exO8=";
+    };
+
+    nativeBuildInputs = [
+      prev.autoPatchelfHook
+      (prev.lib.getLib prev.stdenv.cc.cc)
+      prev.expat
+      prev.zlib
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp --no-preserve=mode --recursive \
+        lib \
+        include \
+        $out/
+
+      runHook postInstall
+    '';
+
+    postFixup = ''
+      for lib in $out/lib/lib*.so.*; do
+        lib=''${lib##*/}
+        target=$out/lib/''${lib%.*}
+        if [ ! -e "$target" ]; then
+          ln -s "$lib" "$target"
+        fi
+      done
+
+      for pcfile in $out/lib/pkgconfig/*.pc; do
+        substituteInPlace $pcfile \
+          --replace 'prefix=/usr' "prefix=$out"
+      done
+    '';
+
+    meta = with prev.lib; {
+      description = "IPU firmware and proprietary image processing libraries";
+      homepage = "https://github.com/intel/ipu7-camera-bins";
+      license = licenses.issl;
+      sourceProvenance = with sourceTypes; [ binaryFirmware ];
+      platforms = [ "x86_64-linux" ];
+    };
+  };
+
+  # HAL variants consumed by different IPU7 targets.
+  ipu7-camera-hal = prev.callPackage ipu7CameraHalPkg { };
+  ipu7x-camera-hal = prev.callPackage ipu7CameraHalPkg { ipuVersion = "ipu7x"; };
+  ipu75xa-camera-hal = prev.callPackage ipu7CameraHalPkg { ipuVersion = "ipu75xa"; };
+
+  # icamerasrc variants used by v4l2-relayd and PipeWire paths.
+  icamerasrc-ipu7x = prev.callPackage icamerasrcIpuPkg {
+    ipuCameraHal = final.ipu7x-camera-hal;
+  };
+
+  icamerasrc-ipu75xa = prev.callPackage icamerasrcIpuPkg {
+    ipuCameraHal = final.ipu75xa-camera-hal;
+  };
+}

--- a/overlays/snapshot.nix
+++ b/overlays/snapshot.nix
@@ -1,0 +1,20 @@
+_: _: prev: {
+  # Global Snapshot wrapper to avoid GTK/Vulkan crashes on some Intel systems.
+  snapshot = prev.symlinkJoin {
+    name = "snapshot-safe";
+    paths = [ prev.snapshot ];
+    nativeBuildInputs = [ prev.makeWrapper ];
+    postBuild = ''
+      rm -f "$out/share/dbus-1/services/org.gnome.Snapshot.service"
+      cat > "$out/share/dbus-1/services/org.gnome.Snapshot.service" <<EOF
+      [D-BUS Service]
+      Name=org.gnome.Snapshot
+      Exec=$out/bin/snapshot --gapplication-service
+      EOF
+
+      wrapProgram $out/bin/snapshot \
+        --set GSK_RENDERER cairo \
+        --set GDK_DISABLE vulkan
+    '';
+  };
+}

--- a/packages/linux/ipu7-drivers/0001-media-ipu7-Stop-accessing-streams-configs-directly.patch
+++ b/packages/linux/ipu7-drivers/0001-media-ipu7-Stop-accessing-streams-configs-directly.patch
@@ -1,0 +1,41 @@
+From 02e5e2239224407e996209939dbf65dc6f79132c Mon Sep 17 00:00:00 2001
+From: Atlas Yu <pseudoc@163.com>
+Date: Fri, 9 Jan 2026 15:33:14 +0800
+Subject: [PATCH] media: ipu7: Stop accessing streams configs directly
+
+The v4l2_subdev_stream_config structure is private after Linux 6.18, now
+iterate over routes instead to get the stream's ID.
+---
+ drivers/media/pci/intel/ipu7/ipu7-isys-video.c | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/media/pci/intel/ipu7/ipu7-isys-video.c b/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
+index de3ebf9..501a1ea 100644
+--- a/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
++++ b/drivers/media/pci/intel/ipu7/ipu7-isys-video.c
+@@ -864,19 +864,17 @@ static u32 get_remote_pad_stream(struct media_pad *r_pad)
+ {
+ 	struct v4l2_subdev_state *state;
+ 	struct v4l2_subdev *sd;
++	struct v4l2_subdev_route *route;
+ 	u32 stream_id = 0;
+-	unsigned int i;
+ 
+ 	sd = media_entity_to_v4l2_subdev(r_pad->entity);
+ 	state = v4l2_subdev_lock_and_get_active_state(sd);
+ 	if (!state)
+ 		return 0;
+ 
+-	for (i = 0; i < state->stream_configs.num_configs; i++) {
+-		struct v4l2_subdev_stream_config *cfg =
+-			&state->stream_configs.configs[i];
+-		if (cfg->pad == r_pad->index) {
+-			stream_id = cfg->stream;
++	for_each_active_route(&state->routing, route) {
++		if (route->source_pad == r_pad->index) {
++			stream_id = route->source_stream;
+ 			break;
+ 		}
+ 	}
+-- 
+2.51.2

--- a/packages/linux/ipu7-drivers/default.nix
+++ b/packages/linux/ipu7-drivers/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+
+stdenv.mkDerivation {
+  pname = "ipu7-drivers";
+  version = "unstable-2025-11-12";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ipu7-drivers";
+    rev = "fc335577f95bf6ca3afc706d1ceab8297db4f010";
+    hash = "sha256-tRljxzo/WsFBLi/1YqxVRtXpSZzHRqIy3RZ8/heu7mI=";
+  };
+
+  ivscSrc = fetchFromGitHub {
+    owner = "intel";
+    repo = "ivsc-driver";
+    rev = "10f440febe87419d5c82d8fe48580319ea135b54";
+    hash = "sha256-jc+8geVquRtaZeIOtadCjY9F162Rb05ptE7dk8kuof0=";
+  };
+
+  patches = [
+    ./0001-media-ipu7-Stop-accessing-streams-configs-directly.patch
+  ];
+
+  postPatch = ''
+    cp --no-preserve=mode --recursive --verbose \
+      $ivscSrc/backport-include \
+      $ivscSrc/drivers \
+      $ivscSrc/include \
+      .
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    sed -i -e "s,INSTALL_MOD_DIR=,INSTALL_MOD_PATH=$out INSTALL_MOD_DIR=," Makefile
+  '';
+
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/intel/ipu7-drivers";
+    description = "IPU7 kernel driver";
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "6.12";
+  };
+}

--- a/packages/linux/vision-drivers/0001-intel-cvs-don-t-fail-probe-on-host-identifier.patch
+++ b/packages/linux/vision-drivers/0001-intel-cvs-don-t-fail-probe-on-host-identifier.patch
@@ -1,0 +1,32 @@
+From e9676f0127a37d40d715fdecc31fbbadf4ffd9a0 Mon Sep 17 00:00:00 2001
+From: vereis <me@vereis.com>
+Date: Tue, 7 Apr 2026 12:35:00 +0100
+Subject: [PATCH] intel-cvs: don't fail probe on host identifier
+
+On some Lunar Lake systems, SET_HOST_IDENTIFIER returns -EIO even though
+camera sensor acquisition can still proceed. Downgrade this to a warning
+to allow probe to continue.
+---
+ drivers/misc/icvs/intel_cvs.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/misc/icvs/intel_cvs.c b/drivers/misc/icvs/intel_cvs.c
+index cf5cb4e..b2ec40f 100644
+--- a/drivers/misc/icvs/intel_cvs.c
++++ b/drivers/misc/icvs/intel_cvs.c
+@@ -167,10 +167,9 @@ static int cvs_common_probe(struct device *dev, bool is_i2c)
+ 			}
+ 
+ 			ret = cvs_write_i2c(SET_HOST_IDENTIFIER, NULL, 0);
+-			if (ret) {
+-				dev_err(cvs->dev, "%s:set_host_identifier cmd failed", __func__);
+-				goto exit;
+-			}
++			if (ret)
++				dev_warn(cvs->dev, "%s:set_host_identifier cmd failed (non-fatal)",
++					 __func__);
+ 		}
+ 	}
+ 
+-- 
+2.51.2

--- a/packages/linux/vision-drivers/default.nix
+++ b/packages/linux/vision-drivers/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+
+stdenv.mkDerivation {
+  # Intel CVS kernel module is required so the OV02C10 sensor powers up and
+  # gets discovered reliably on Lunar Lake / XPS 13 9350 camera stack.
+  pname = "vision-drivers";
+  version = "unstable-2026-03-17";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "vision-drivers";
+    rev = "a8d772f261bc90376944956b7bfd49b325ffa2f2";
+    hash = "sha256-zOvCZKGwOGT9kcJiefzx/duHqR0V8PYhNbqsMHkH1r4=";
+  };
+
+  patches = [
+    ./0001-intel-cvs-don-t-fail-probe-on-host-identifier.patch
+  ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    sed -i -e "s,INSTALL_MOD_DIR=,INSTALL_MOD_PATH=$out INSTALL_MOD_DIR=," Makefile
+  '';
+
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/intel/vision-drivers";
+    description = "Intel CVS kernel driver for Lunar Lake camera stack";
+    license = licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
+    broken = kernel.kernelOlder "6.7";
+  };
+}

--- a/parts/overlays.nix
+++ b/parts/overlays.nix
@@ -7,7 +7,9 @@ in
     overlays = {
       default = lib.composeManyExtensions [
         (import ../overlays/crit.nix inputs)
+        (import ../overlays/ipu7-camera.nix inputs)
         (import ../overlays/opencode.nix inputs)
+        (import ../overlays/snapshot.nix inputs)
         (import ../overlays/slack.nix inputs)
       ];
     };


### PR DESCRIPTION
## Summary
- add a dedicated `modules/hardware/dell/xps/13-9350` hardware stack that enables Intel IPU7 camera support, includes OV02C10 orientation/color kernel backports, and isolates model-specific microphone fixes
- add local Intel camera packaging (`overlays/ipu7-camera.nix`, `packages/linux/ipu7-drivers`, `packages/linux/vision-drivers`) plus WirePlumber/v4l2-relayd integration so GNOME Snapshot and Slack/Teams can use the built-in webcam reliably
- move Snapshot safety wrapping into a global overlay (`overlays/snapshot.nix`) and update docs/overlay wiring for the new hardware and package layout

## Validation
- `sudo nixos-rebuild switch --flake .#iroha`
- pre-commit hooks passed during commit (`deadnix`, `nix flake check`, `statix`, `treefmt`, `convco`)